### PR TITLE
Find Issues command

### DIFF
--- a/voxelbot/plugins/easy_github_contribution.py
+++ b/voxelbot/plugins/easy_github_contribution.py
@@ -17,6 +17,7 @@ ACCEPT_BUTTON = Button("Accept", emoji=ACCEPT_EMOJI, custom_id="egc.accept", sty
 DENY_BUTTON = Button("Deny", emoji=DENY_EMOJI, custom_id="egc.deny", style=ButtonStyle.red)
 COMPONENTS = Row(ACCEPT_BUTTON, DENY_BUTTON)
 
+VOXEL51_REPOS = [r.name for r in GITHUB.get_repos(type="public")]
 
 @ALL.events  # type: ignore
 async def message_create(client: Client, message: Message):
@@ -131,3 +132,46 @@ async def egc_deny(client: Client, event: InteractionEvent):
     await client.message_delete(event.message.referenced_message)
     await client.interaction_component_acknowledge(event)
     await client.interaction_response_message_delete(event)
+
+
+@ALL.interactions(is_global=True, wait_for_acknowledgement=True)
+async def search_issues(client: Client, query: ("str", "Topic to search")):  # type: ignore
+    """Allow users to search for relevant GitHub issues and return the top-5 results."""
+    if not query:
+        return await client.message_create(message.channel, "Please provide a search query.")
+
+    try:
+        repo = GITHUB.get_repo("voxel51/fiftyone")
+        issues = repo.search_issues(f'{query} in:title,body')
+        if issues.totalCount == 0:
+            return await client.message_create(message.channel, "No relevant issues found.")
+
+        issue_links = "\n".join(f"{issue.title}: {issue.html_url}" for issue in issues[:5])
+        await client.message_create(message.channel, f"Top relevant issues:\n{issue_links}")
+
+
+@ALL.interactions(is_global=True, wait_for_acknowledgement=True)
+async def ref_issue(query: ("str", "Topic to search"), repo: ("str", "Repo to search.")):  # type: ignore # noqa: F722
+    """Provides specific metric(s) for the voxel51/fiftyone repository."""
+    if repo not in (VOXEL51_REPOS):
+        abort("Must be Voxel51 repo.")
+    GITHUB.get_repo(repo)
+    issues = repo.search_issues(f'{query} in:title,body')
+    
+    if issues.totalCount == 0:
+            return await client.message_create(message.channel, "No relevant issues found.")
+    
+    issue_links = "\n".join(f"{issue.title}: {issue.html_url}" for issue in issues[:5])
+    await client.message_create(message.channel, f"Top relevant issues:\n{issue_links}")
+    
+    except GithubException as e:
+        logging.error(f"GitHub API error: {e}")
+        await client.message_create(message.channel, "An error occurred while searching for issues. Please try again later.")
+
+
+@repo_metrics.autocomplete("repo")
+async def repo_autocomplete(value):
+    if not value:
+        return VOXEL51_REPOS
+    value_lower = value.lower()
+    return [repo for repo in VOXEL51_REPOS if repo.startswith(value_lower)]

--- a/voxelbot/plugins/find_issues.py
+++ b/voxelbot/plugins/find_issues.py
@@ -21,14 +21,15 @@ async def ref_issue(client, event, query: ("str", "Topic to search"), repo: ("st
     elif repo is None:
         repo = "voxel51/fiftyone"  # default
     
-    GITHUB.get_repo(repo)
-    issues = repo.search_issues(f'{query} in:title,body')
-    
-    if issues.totalCount == 0:
+    try:
+        GITHUB.get_repo(repo)
+        issues = repo.search_issues(f'{query} in:title,body')
+        
+        if issues.totalCount == 0:
             return await client.message_create(message.channel, "No relevant issues found.")
-    
-    issue_links = "\n".join(f"{issue.title}: {issue.html_url}" for issue in issues[:5])
-    await client.message_create(event.channel, f"Top relevant issues:\n{issue_links}")
+        
+        issue_links = "\n".join(f"{issue.title}: {issue.html_url}" for issue in issues[:5])
+        await client.message_create(event.channel, f"Top relevant issues:\n{issue_links}")
     
     except GithubException as e:
         logging.error(f"GitHub API error: {e}")

--- a/voxelbot/plugins/find_issues.py
+++ b/voxelbot/plugins/find_issues.py
@@ -22,8 +22,8 @@ async def ref_issue(client, event, query: ("str", "Topic to search"), repo: ("st
         repo = "voxel51/fiftyone"  # default
     
     try:
-        GITHUB.get_repo(repo)
-        issues = repo.search_issues(f'{query} in:title,body')
+        repo = GITHUB.get_repo(repo)
+        issues = GITHUB.search_issues(f"{query} repo:{repo.full_name} in:title,body")
         
         if issues.totalCount == 0:
             return await client.message_create(event.channel, "No relevant issues found.")

--- a/voxelbot/plugins/find_issues.py
+++ b/voxelbot/plugins/find_issues.py
@@ -10,7 +10,7 @@ ALL = ClientWrapper()
 
 GITHUB = Github(auth=Auth.Token(GITHUB_TOKEN))
 ORG = GITHUB.get_organization("voxel51")
-VOXEL51_REPOS = [r.name for r in ORG.get_repos(type="public")]
+VOXEL51_REPOS = [r.full_name for r in ORG.get_repos(type="public")]
 
 
 @ALL.interactions(is_global=True, wait_for_acknowledgement=True)

--- a/voxelbot/plugins/find_issues.py
+++ b/voxelbot/plugins/find_issues.py
@@ -1,7 +1,10 @@
 import logging
 
 from github import Auth, Github, GithubException
-from hata import Client, ClientWrapper
+from github.Issue import Issue
+from github.Organization import Organization
+from github.PaginatedList import PaginatedList
+from hata import Client, ClientWrapper, InteractionEvent
 from hata.ext.slash import abort
 
 from ..constants import GITHUB_TOKEN
@@ -9,8 +12,8 @@ from ..constants import GITHUB_TOKEN
 ALL = ClientWrapper()
 
 GITHUB = Github(auth=Auth.Token(GITHUB_TOKEN))
-ORG = GITHUB.get_organization("voxel51")
-VOXEL51_REPOS = [r.full_name for r in ORG.get_repos(type="public")]
+ORG: Organization = GITHUB.get_organization("voxel51")
+VOXEL51_REPOS: list[str] = [r.full_name for r in ORG.get_repos(type="public")]
 
 
 @ALL.interactions(is_global=True, wait_for_acknowledgement=True)
@@ -21,7 +24,7 @@ async def ref_issue(
     repo: ("str", "Repo to search."),  # type: ignore # noqa: F722
 ):
     """
-    Returns a list of top-five related issues from a specified Voxel51 repository based on the 
+    Returns a list of top-five related issues from a specified Voxel51 repository based on the
     user's query.
 
     Args:
@@ -35,26 +38,41 @@ async def ref_issue(
     """
     if repo not in VOXEL51_REPOS:
         abort("Must be Voxel51 repo.")
-    elif repo is None:
-        repo = "voxel51/fiftyone"  # default
-    
+
     try:
-        issues = GITHUB.search_issues(f"{query} repo:{repo} in:title,body is:issue")
-        
+        issues: PaginatedList[Issue] = GITHUB.search_issues(
+            f"{query} repo:{repo} in:title,body is:issue"
+        )
+
         if issues.totalCount == 0:
             return await client.message_create(event.channel, "No relevant issues found.")
-        
-        issue_links = "\n".join(f"{issue.title}: {issue.html_url}" for issue in issues[:5])
+
+        issue_links: str = "\n".join(f"{issue.title}: {issue.html_url}" for issue in issues[:5])
         await client.message_create(event.channel, f"Top relevant issues:\n{issue_links}")
-    
+
     except GithubException as e:
         logging.error(f"GitHub API error: {e}")
-        await client.message_create(event.channel, "An error occurred while searching for issues. Please try again later.")
+        await client.message_create(
+            event.channel, "An error occurred while searching for issues. Please try again later."
+        )
 
 
 @ref_issue.autocomplete("repo")
-async def repo_autocomplete(value):
+async def repo_autocomplete(value) -> list[str]:
+    """
+    Provides autocomplete suggestions for repository names.
+
+    This function is triggered by the `ref_issue.autocomplete` decorator with the
+    argument "repo". It returns a list of repository names that match the given
+    input value. If no value is provided, it returns the full list of repositories.
+
+    Args:
+        value (str): The input value to match against repository names.
+
+    Returns:
+        list[str]: A list of repository names that start with the input value.
+    """
     if not value:
         return VOXEL51_REPOS
-    value_lower = value.lower()
+    value_lower: str = value.lower()
     return [repo for repo in VOXEL51_REPOS if repo.startswith(value_lower)]

--- a/voxelbot/plugins/find_issues.py
+++ b/voxelbot/plugins/find_issues.py
@@ -15,8 +15,10 @@ VOXEL51_REPOS = [r.name for r in GITHUB.get_repos(type="public")]
 @ALL.interactions(is_global=True, wait_for_acknowledgement=True)
 async def ref_issue(client, event, query: ("str", "Topic to search"), repo: ("str", "Repo to search.")):  # type: ignore # noqa: F722
     """Provides specific metric(s) for the voxel51/fiftyone repository."""
-    if repo not in (VOXEL51_REPOS):
+    if repo is not None and not in (VOXEL51_REPOS):
         abort("Must be Voxel51 repo.")
+    elif repo is None:
+        repo = "voxel51/fiftyone"  # default
     
     GITHUB.get_repo(repo)
     issues = repo.search_issues(f'{query} in:title,body')

--- a/voxelbot/plugins/find_issues.py
+++ b/voxelbot/plugins/find_issues.py
@@ -15,7 +15,7 @@ VOXEL51_REPOS = [r.name for r in GITHUB.get_repos(type="public")]
 @ALL.interactions(is_global=True, wait_for_acknowledgement=True)
 async def ref_issue(client, event, query: ("str", "Topic to search"), repo: ("str", "Repo to search.")):  # type: ignore # noqa: F722
     """Provides specific metric(s) for the voxel51/fiftyone repository."""
-    if repo is not None and not in (VOXEL51_REPOS):
+    if repo is not None and repo not in (VOXEL51_REPOS):
         abort("Must be Voxel51 repo.")
     elif repo is None:
         repo = "voxel51/fiftyone"  # default

--- a/voxelbot/plugins/find_issues.py
+++ b/voxelbot/plugins/find_issues.py
@@ -14,9 +14,26 @@ VOXEL51_REPOS = [r.full_name for r in ORG.get_repos(type="public")]
 
 
 @ALL.interactions(is_global=True, wait_for_acknowledgement=True)
-async ref_issue(client: Client, event: InteractionEvent, query: ("str", "Topic to search"), repo: ("str", "Repo to search.")):  # type: ignore # noqa: F722
-    """Returns list of top-five related issues from Voxel51 repository based on user query."""
-    if repo is not None and repo not in VOXEL51_REPOS:
+async def ref_issue(
+    client: Client,
+    event: InteractionEvent,
+    query: ("str", "Topic to search"),  # type: ignore # noqa: F722
+    repo: ("str", "Repo to search."),  # type: ignore # noqa: F722
+):
+    """
+    Returns a list of top-five related issues from a specified Voxel51 repository based on the 
+    user's query.
+
+    Args:
+        client (Client): The client instance to use for sending messages.
+        event (InteractionEvent): The interaction event that triggered this function.
+        query (str): The topic to search for in the issues.
+        repo (str): The repository to search within.
+
+    Raises:
+        GithubException: If there is an error with the GitHub API request.
+    """
+    if repo not in VOXEL51_REPOS:
         abort("Must be Voxel51 repo.")
     elif repo is None:
         repo = "voxel51/fiftyone"  # default

--- a/voxelbot/plugins/find_issues.py
+++ b/voxelbot/plugins/find_issues.py
@@ -26,7 +26,7 @@ async def ref_issue(client, event, query: ("str", "Topic to search"), repo: ("st
         issues = repo.search_issues(f'{query} in:title,body')
         
         if issues.totalCount == 0:
-            return await client.message_create(message.channel, "No relevant issues found.")
+            return await client.message_create(event.channel, "No relevant issues found.")
         
         issue_links = "\n".join(f"{issue.title}: {issue.html_url}" for issue in issues[:5])
         await client.message_create(event.channel, f"Top relevant issues:\n{issue_links}")

--- a/voxelbot/plugins/find_issues.py
+++ b/voxelbot/plugins/find_issues.py
@@ -1,6 +1,6 @@
 import logging
 
-from github import Auth, Github
+from github import Auth, Github, GithubException
 from hata import Client, ClientWrapper
 from hata.ext.slash import abort
 
@@ -15,7 +15,7 @@ VOXEL51_REPOS = [r.name for r in GITHUB.get_repos(type="public")]
 @ALL.interactions(is_global=True, wait_for_acknowledgement=True)
 async def ref_issue(client, event, query: ("str", "Topic to search"), repo: ("str", "Repo to search.")):  # type: ignore # noqa: F722
     """Provides specific metric(s) for the voxel51/fiftyone repository."""
-    if repo is not None and repo not in (VOXEL51_REPOS):
+    if repo is not None and repo not in VOXEL51_REPOS:
         abort("Must be Voxel51 repo.")
     elif repo is None:
         repo = "voxel51/fiftyone"  # default
@@ -34,7 +34,7 @@ async def ref_issue(client, event, query: ("str", "Topic to search"), repo: ("st
         await client.message_create(event.channel, "An error occurred while searching for issues. Please try again later.")
 
 
-@repo_metrics.autocomplete("repo")
+@ref_issue.autocomplete("repo")
 async def repo_autocomplete(value):
     if not value:
         return VOXEL51_REPOS

--- a/voxelbot/plugins/find_issues.py
+++ b/voxelbot/plugins/find_issues.py
@@ -1,0 +1,40 @@
+import logging
+
+from github import Auth, Github
+from hata import Client, ClientWrapper
+from hata.ext.slash import abort
+
+from ..constants import GITHUB_TOKEN
+
+ALL = ClientWrapper()
+
+GITHUB = Github(auth=Auth.Token(GITHUB_TOKEN))
+VOXEL51_REPOS = [r.name for r in GITHUB.get_repos(type="public")]
+
+
+@ALL.interactions(is_global=True, wait_for_acknowledgement=True)
+async def ref_issue(client, event, query: ("str", "Topic to search"), repo: ("str", "Repo to search.")):  # type: ignore # noqa: F722
+    """Provides specific metric(s) for the voxel51/fiftyone repository."""
+    if repo not in (VOXEL51_REPOS):
+        abort("Must be Voxel51 repo.")
+    
+    GITHUB.get_repo(repo)
+    issues = repo.search_issues(f'{query} in:title,body')
+    
+    if issues.totalCount == 0:
+            return await client.message_create(message.channel, "No relevant issues found.")
+    
+    issue_links = "\n".join(f"{issue.title}: {issue.html_url}" for issue in issues[:5])
+    await client.message_create(event.channel, f"Top relevant issues:\n{issue_links}")
+    
+    except GithubException as e:
+        logging.error(f"GitHub API error: {e}")
+        await client.message_create(event.channel, "An error occurred while searching for issues. Please try again later.")
+
+
+@repo_metrics.autocomplete("repo")
+async def repo_autocomplete(value):
+    if not value:
+        return VOXEL51_REPOS
+    value_lower = value.lower()
+    return [repo for repo in VOXEL51_REPOS if repo.startswith(value_lower)]

--- a/voxelbot/plugins/find_issues.py
+++ b/voxelbot/plugins/find_issues.py
@@ -23,7 +23,7 @@ async def ref_issue(client, event, query: ("str", "Topic to search"), repo: ("st
     
     try:
         repo = GITHUB.get_repo(repo)
-        issues = GITHUB.search_issues(f"{query} repo:{repo.full_name} in:title,body")
+        issues = GITHUB.search_issues(f"{query} repo:{repo.full_name} in:title,body is:issue")
         
         if issues.totalCount == 0:
             return await client.message_create(event.channel, "No relevant issues found.")

--- a/voxelbot/plugins/find_issues.py
+++ b/voxelbot/plugins/find_issues.py
@@ -15,7 +15,7 @@ VOXEL51_REPOS = [r.full_name for r in ORG.get_repos(type="public")]
 
 @ALL.interactions(is_global=True, wait_for_acknowledgement=True)
 async def ref_issue(client, event, query: ("str", "Topic to search"), repo: ("str", "Repo to search.")):  # type: ignore # noqa: F722
-    """Provides specific metric(s) for the voxel51/fiftyone repository."""
+    """Returns list of top-five related issues from Voxel51 repository based on user query."""
     if repo is not None and repo not in VOXEL51_REPOS:
         abort("Must be Voxel51 repo.")
     elif repo is None:

--- a/voxelbot/plugins/find_issues.py
+++ b/voxelbot/plugins/find_issues.py
@@ -14,7 +14,7 @@ VOXEL51_REPOS = [r.full_name for r in ORG.get_repos(type="public")]
 
 
 @ALL.interactions(is_global=True, wait_for_acknowledgement=True)
-async def ref_issue(client, event, query: ("str", "Topic to search"), repo: ("str", "Repo to search.")):  # type: ignore # noqa: F722
+async ref_issue(client: Client, event: InteractionEvent, query: ("str", "Topic to search"), repo: ("str", "Repo to search.")):  # type: ignore # noqa: F722
     """Returns list of top-five related issues from Voxel51 repository based on user query."""
     if repo is not None and repo not in VOXEL51_REPOS:
         abort("Must be Voxel51 repo.")

--- a/voxelbot/plugins/find_issues.py
+++ b/voxelbot/plugins/find_issues.py
@@ -9,7 +9,8 @@ from ..constants import GITHUB_TOKEN
 ALL = ClientWrapper()
 
 GITHUB = Github(auth=Auth.Token(GITHUB_TOKEN))
-VOXEL51_REPOS = [r.name for r in GITHUB.get_repos(type="public")]
+ORG = GITHUB.get_organization("voxel51")
+VOXEL51_REPOS = [r.name for r in ORG.get_repos(type="public")]
 
 
 @ALL.interactions(is_global=True, wait_for_acknowledgement=True)

--- a/voxelbot/plugins/find_issues.py
+++ b/voxelbot/plugins/find_issues.py
@@ -22,8 +22,7 @@ async ref_issue(client: Client, event: InteractionEvent, query: ("str", "Topic t
         repo = "voxel51/fiftyone"  # default
     
     try:
-        repo = GITHUB.get_repo(repo)
-        issues = GITHUB.search_issues(f"{query} repo:{repo.full_name} in:title,body is:issue")
+        issues = GITHUB.search_issues(f"{query} repo:{repo} in:title,body is:issue")
         
         if issues.totalCount == 0:
             return await client.message_create(event.channel, "No relevant issues found.")


### PR DESCRIPTION
# Rationale

<!-- Explain why you are making this change. Describe the problem. -->

Brief exchange with SteveO on the [docs repo](https://github.com/voxel51/voxel51-docs/issues/23#issuecomment-2659519921) made me think this could be a good addition.

## Changes

<!-- Describe the changes. -->

Adds Discord `/ref_issue` command, that allows users to search for 5 relevant issues. Includes two arguments `repo` and `query` to allow specifying the repo to search and the keywords in title/topic of Issues to find.

## Testing

<!-- Describe the way the changes were tested. -->

😆 unfortunately not at all. Did my best to mirror what other sections of code were doing and to make sure it had a logical flow.  Not sure if the "default" behavior included (try to search `voxel51/fiftyone` if no repo is specified).

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
