### PR TITLE
Shortens docstring `ref_issue`

### DIFF
--- a/voxelbot/plugins/find_issues.py
+++ b/voxelbot/plugins/find_issues.py
@@ -24,8 +24,7 @@ async def ref_issue(
     repo: ("str", "Repo to search."),  # type: ignore # noqa: F722
 ):
     """
-    Returns a list of top-five related issues from a specified Voxel51 repository based on the
-    user's query.
+    Returns top-five related issues from a Voxel51 repository based on the user's query.
 
     Args:
         client (Client): The client instance to use for sending messages.


### PR DESCRIPTION
# Rationale

<!-- Explain why you are making this change. Describe the problem. -->

https://github.com/voxel51/VoxelBot/pull/3#issuecomment-2671599946

```
ValueError: `description` length is out of the expected range [2:100], got 104; "Returns a list of top-five related issues from a specified Voxel51 repository based on the user's query.".
```

## Changes

<!-- Describe the changes. -->

Shortened docstring, now 84 characters.

## Testing

<!-- Describe the way the changes were tested. -->

<!-- Optional Sections:

## Screenshots
## To Do
## Notes

Unclear if the same will be needed for `repo_autocomplete` function. First line of this function is only 55 characters.

## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
