### PR TITLE
chore: Fix ansible/yq zones

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -62,13 +62,14 @@ jobs:
           DOCKER_REGISTRY: "${{ secrets.GCP_LOCATION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT }}/${{ secrets.GCP_DOCKER_REPOSITORY }}/"
           GCP_SM_KEY: "${{ secrets.GCP_SM_KEY }}"
           TAG: ${{ github.sha }}
-          GCP_COMPUTE_SERVER_NAME: "${{ secrets.GCP_COMPUTE_SERVER_NAME }}"
-          GCP_LOCATION: ${{ secrets.GCP_LOCATION }}
+          GCP_COMPUTE_SERVER_NAME: ${{ secrets.GCP_COMPUTE_SERVER_NAME }}
+          GCP_COMPUTE_SERVER_ZONE: ${{ secrets.GCP_COMPUTE_SERVER_ZONE }} # Zone
+          GCP_LOCATION: ${{ secrets.GCP_LOCATION }} # Region
           GCP_PROJECT: ${{ secrets.GCP_PROJECT }}
         run: |
           pushd ansible
           yq -i ".projects |= [\"$GCP_PROJECT\"]" ./inventory/gcp.yml
-          yq -i ".zones |= [\"$GCP_LOCATION\"]" ./inventory/gcp.yml
+          yq -i ".zones |= [\"$GCP_COMPUTE_SERVER_ZONE\"]" ./inventory/gcp.yml
           sudo pipx inject ansible-core -r requirements.txt
           ansible-playbook site.yml
           popd

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ dependencies = [
     "hata[all]",
     "pygithub",
     "aiosqlite",
-    "inotify-simple",
     "pygal",
     "cairosvg",
     "cryptography",


### PR DESCRIPTION
# Rationale

I noticed that a recent action didn't deploy the image as expected. This is because `GCP_LOCATION` is a region and VMs work on a zonal level. I will add a `GCP_COMPUTE_SERVER_ZONE` so that our dynamic inventory can work as expected.

Also, inotify-simple causes random build failures and isn't required. Removing.

## Changes

Adds 

```
          GCP_COMPUTE_SERVER_ZONE: ${{ secrets.GCP_COMPUTE_SERVER_ZONE }} # Zone
```

and changes the `yq` command to reference this.

## Testing

<!-- Describe the way the changes were tested. -->

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
