### PR TITLE
chore(asdf): AS-596 utilize asdf set and bump asdf action

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -14,5 +14,5 @@ jobs:
       - uses: actions/checkout@v4.1.6
       - uses: actions/setup-python@v5.2.0
       - name: install asdf & tools
-        uses: asdf-vm/actions/install@v3.0.2
+        uses: asdf-vm/actions/install@9cd779f40fe38688dd19505ccbc4eaaf018b44e7
       - uses: pre-commit/action@v3.0.1

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ asdf:  ## Update plugins, add plugins, install plugins, set local, reshim
 	@cat .tool-versions | xargs -I{} bash -c 'asdf install {}'
 
 	@echo "Setting local package versions..."
-	@cat .tool-versions | xargs -I{} bash -c 'asdf local {}'
+	@cat .tool-versions | xargs -I{} bash -c 'asdf set {}'
 
 	@echo "Reshimming.."
 	@asdf reshim


### PR DESCRIPTION
# Rationale

`asdf local` is deprecated and removed in newer versions. We can switch to `asdf set`. We can also bump to the newer action to avoid that deprecation notice which munges STDOUT.

## Changes

* Bump ASDF action to use the latest SHA
* Migrate from `asdf local` to `asdf set`

## Testing

<!-- Describe the way the changes were tested. -->

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
