### PR TITLE
build(actions): AS-626 migrate to shared actions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,7 +12,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.6
-      - uses: actions/setup-python@v5.2.0
-      - name: install asdf & tools
-        uses: asdf-vm/actions/install@9cd779f40fe38688dd19505ccbc4eaaf018b44e7
-      - uses: pre-commit/action@v3.0.1
+      - name: Run pre-commit
+        uses: "voxel51/aloha-github-workflows/.github/actions/pre-commit@main"


### PR DESCRIPTION
# Rationale

We recently implemented a [repository](https://github.com/voxel51/aloha-github-workflows) with shared github actions! We can begin to reduce our copy/paste by migrating over to these new shared workflows. This limits our dependence on public dependencies and co-locates common actions.

## Changes

Uses the shared `pre-commit` action.

```yaml
      - name: Run pre-commit
        uses: "voxel51/aloha-github-workflows/.github/actions/pre-commit@main"
```
## Testing

<!-- Describe the way the changes were tested. -->

<!-- Optional Sections:

## Screenshots
## To Do
## Notes
## Related

-->

<!-- Template for collapsed sections
<details>
<summary></summary>
</details>
-->
